### PR TITLE
Fix setting of writable DCI registers

### DIFF
--- a/drivers/staging/most/hdm-usb/hdm_usb.c
+++ b/drivers/staging/most/hdm-usb/hdm_usb.c
@@ -1018,7 +1018,7 @@ static ssize_t store_value(struct most_dci_obj *dci_obj,
 		err = drci_wr_reg(usb_dev, dci_obj->reg_addr, val);
 	else if (!strcmp(name, "sync_ep"))
 		err = start_sync_ep(usb_dev, val);
-	else if (!get_static_reg_addr(ro_regs, name, &reg_addr))
+	else if (!get_static_reg_addr(rw_regs, name, &reg_addr))
 		err = drci_wr_reg(usb_dev, reg_addr, val);
 	else
 		return -EFAULT;


### PR DESCRIPTION
The function store_value is about writing a value, but the code has been
passing ro_regs array to get_static_reg_addr, which prevented setting
the writable registers.

Noticed when trying to setup the EUI48.

Signed-off-by: Alex Riesen <alexander.riesen@cetitec.com>